### PR TITLE
Add favorite music section

### DIFF
--- a/src/lib/i18n/en.js
+++ b/src/lib/i18n/en.js
@@ -4,7 +4,8 @@ export const en = {
 		title: 'Hasan BÖCEK',
 		subtitle: 'Backend Developer & Electrical and Electronics Engineering Student',
 		quote: "Trust me, i'm an engineer !",
-		quoteAuthor: "Igor Pachmelnik Zakuskov"
+		quoteAuthor: 'Igor Pachmelnik Zakuskov',
+		favoriteMusic: 'Favorite Music: Linkin Park - Numb'
 	},
 
 	// Social
@@ -61,7 +62,7 @@ export const en = {
 				description:
 					'A system for the management of the tennis club, where members can be managed, group lessons can be created and attendance can be taken',
 				tech: ['Svelte', 'Node.JS', 'MongoDB']
-				},
+			},
 			{
 				title: 'ToonApp - IOS Mentorship Application',
 				description:
@@ -70,8 +71,7 @@ export const en = {
 			},
 			{
 				title: 'FR - Recipe Sharing Application',
-				description:
-					'A platform where users can add, search, evaluate and share recipes',
+				description: 'A platform where users can add, search, evaluate and share recipes',
 				tech: ['Node.js', 'Express', 'MongoDB', 'Next.js'],
 				github: 'https://github.com/HasanBocek/Food-Recipe-Backend'
 			},
@@ -86,7 +86,7 @@ export const en = {
 				title: 'SPT - Student Process Tracking',
 				description:
 					'A system that enables educational institutions to track student progress and performance and provides analytics for instructors and administrators',
-				tech: ['Node.js', 'Express', 'MongoDB', "EJS", "Bootstrap"],
+				tech: ['Node.js', 'Express', 'MongoDB', 'EJS', 'Bootstrap'],
 				github: 'https://github.com/HasanBocek/spt'
 			}
 		],

--- a/src/lib/i18n/tr.js
+++ b/src/lib/i18n/tr.js
@@ -4,7 +4,8 @@ export const tr = {
 		title: 'Hasan BÖCEK',
 		subtitle: 'Backend Geliştirici & Elektrik Elektronik Mühendisliği Öğrencisi',
 		quote: "Trust me, i'm an engineer !",
-		quoteAuthor: "Igor Pachmelnik Zakuskov"
+		quoteAuthor: 'Igor Pachmelnik Zakuskov',
+		favoriteMusic: 'Favori Müzik: Linkin Park - Numb'
 	},
 
 	// Social
@@ -61,7 +62,7 @@ export const tr = {
 				description:
 					'Tenis kulübünün yönetimi için, üyelerin yönetilebildiği, grup derslerinin oluşturulabildiği ve yoklamaların alınabilindiği bir sistem',
 				tech: ['Svelte', 'Node.JS', 'MongoDB']
-				},
+			},
 			{
 				title: 'ToonApp - IOS Mentorluk Uygulaması',
 				description:
@@ -86,7 +87,7 @@ export const tr = {
 				title: 'SPT - Öğrenci Süreç Takip Uygulaması',
 				description:
 					'Eğitim kurumları için öğrenci ilerlemesi ve performansının takibini sağlayan, eğitmenler ve yöneticiler için analiz özellikleri sunan bir sistem',
-				tech: ['Node.js', 'Express', 'MongoDB', "EJS", "Bootstrap"],
+				tech: ['Node.js', 'Express', 'MongoDB', 'EJS', 'Bootstrap'],
 				github: 'https://github.com/HasanBocek/spt'
 			}
 		],

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
 					</p>
 					<footer class="mb-2 text-xs text-gray-400">– {$t('hero.quoteAuthor')}</footer>
 				</blockquote>
+				<p class="mb-4 text-gray-600">{$t('hero.favoriteMusic')}</p>
 				<div class="flex space-x-4">
 					{#each $t('socialLinks') as social}
 						<a


### PR DESCRIPTION
## Summary
- expand i18n dictionaries with favorite music
- show favorite music below the quote on the homepage

## Testing
- `npm run lint`
- `npm run check` *(fails: Parameter 'node' implicitly has an 'any' type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b896868ec8328adb27e1033bb070c